### PR TITLE
Ensure file encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.project
 *.pydevproject
 *.kpf
+.python-version
 venv
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm

--- a/prepare/address.py
+++ b/prepare/address.py
@@ -23,7 +23,7 @@ def write_address(csvfile):
     TOWN = 8
 
     address_set = set()
-    with open(csvfile, newline="") as cf:
+    with open(csvfile, newline="", encoding="shift_jis") as cf:
         rows = csv.reader(cf, delimiter=",")
         for row in rows:
             address = "".join([row[PREFECTURE], row[CITY]])


### PR DESCRIPTION
Encoding of address file is shift-jis. In unix system (my environment is ubuntu),reading file without encoding causes UnicodeDecodeError.
